### PR TITLE
Update/typos fragments

### DIFF
--- a/bin/lib/typos.js
+++ b/bin/lib/typos.js
@@ -23,25 +23,25 @@ if (process.env.hasOwnProperty('PHRASES' )) {
 //   'the a' : '(>A<\\/mark>|“<mark[^>]+>a<\\/mark>”)', // NB the details of the speech marks
 // }
 
-// for clarity, break out the regex for a phrase into a list of individual fragments,
-// each of which is a not typo, then concat them with pipes into one regex for each phrase.
+// for clarity, break out the regex for a phrase into a map of individual fragments,
+// each of which is a not typo, with an example, then concat the keys with pipes into one regex for each phrase.
 let notTyposFragments = { // default
-  'a a'   : [
-    '&amp;<mark',
-    '>A<\\/mark>\\$'
-  ],
-  'a the' : [
-    '-<mark[^>]+>[aA]<',
-    '>[aA]<\\/mark>\\)',
-    '&amp;<mark[^>]+>A<'
-  ],
-  'an the' : [
-    'Ping <mark[^>]+>An<'
-  ],
-  'the a' : [
-    '>A<\\/mark>',
-    '“<mark[^>]+>a<\\/mark>”' // NB the details of the speech marks
-  ],
+  'a a'   : {
+    '&amp;<mark'     : 'making M&A a potentially',
+    '>A<\\/mark>\\$' : 'and a A$100bn',
+  },
+  'a the' : {
+    '-<mark[^>]+>[aA]<'  : 'as triple-A. The agency',
+    '>[aA]<\\/mark>\\)'  : 'What is new is a) the declining',
+    '&amp;<mark[^>]+>A<' : 'Banking M&A: the quest',
+  },
+  'an the' : {
+    'Ping <mark[^>]+>An<' : 'like Ping An, the insurance group'
+  },
+  'the a' : {
+    '>A<\\/mark>'             : 'including the A321XLR launched; to the A level syllabus',
+    '“<mark[^>]+>a<\\/mark>”' : 'Hera was the “a” removed' // NB the details of the speech marks
+  },
 }
 
 if (process.env.hasOwnProperty('NOTTYPOSFRAGMENTS' )) {
@@ -61,7 +61,7 @@ if (process.env.hasOwnProperty('NOTTYPOSFRAGMENTS' )) {
 const notTypos = {};
 Object.keys(notTyposFragments).map( phrase => {
   const fragments = notTyposFragments[phrase];
-  notTypos[phrase] = fragments.join('|');
+  notTypos[phrase] = Object.keys(fragments).join('|');
 });
 
 const standardCandles = [

--- a/bin/lib/typos.js
+++ b/bin/lib/typos.js
@@ -39,10 +39,16 @@ let notTyposFragments = { // default
   'an the' : {
     'Ping <mark[^>]+>An<' : 'like Ping An, the insurance group'
   },
+  'said said' : {
+    '>said<\\/mark>[^>]+>Said<\\/mark>' : 'said Said Jahani',
+  },
   'the a' : {
     '>A<\\/mark>'             : 'including the A321XLR launched; to the A level syllabus',
     '“<mark[^>]+>a<\\/mark>”' : 'Hera was the “a” removed' // NB the details of the speech marks
   },
+  'were were' : {
+    '“<mark[^>]+>Were<\\/mark>[^>]+>Were<\\/mark>”' : 'He ended with “Were Were”, drums firing like gunshots', 
+  }
 }
 
 if (process.env.hasOwnProperty('NOTTYPOSFRAGMENTS' )) {

--- a/bin/lib/typos.js
+++ b/bin/lib/typos.js
@@ -29,6 +29,7 @@ let notTyposFragments = { // default
   'a a'   : {
     '&amp;<mark'     : 'making M&A a potentially',
     '>A<\\/mark>\\$' : 'and a A$100bn',
+    '>A<\\/mark>[^>]+>a<\\/mark>' : 'Article 35A, a constitutional provision'
   },
   'a the' : {
     '-<mark[^>]+>[aA]<'  : 'as triple-A. The agency',

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -5,7 +5,7 @@
 <h3>Look for standard typos</h3>
 <p>There will be a delay whilst the site's search is poked repeatedly.</p>
 <ul>
-  <li>raw json data: GET <a href="/typos/raw">/typos/raw</a> (also ?maxdays=31)</li>
+  <li>raw json data: GET <a href="/typos/raw">/typos/raw</a> (also ?maxdays=31, includes details of each matching result in the standfirst field)</li>
   <li>tidy view: GET <a href="/typos/tidy">/typos/tidy</a> (also ?maxdays=31)</li>
   <li>config: GET <a href="/typos/config">/typos/config</a></li>
 </ul>


### PR DESCRIPTION
refactored handling of not-typos, so it is easier to read the regexs which catch the "that's no typo" edge cases.

You can view all the underlying details of the /typos/tidy view in the /typos/raw view, which includes the not-typos fragments etc, and the SAPI texts of the candidate typos.